### PR TITLE
Parse generic records.

### DIFF
--- a/src/elm/ast.gleam
+++ b/src/elm/ast.gleam
@@ -53,6 +53,7 @@ pub type TypeAnnotation {
   Tupled(List(TypeAnnotation))
   Typed(TypeName, List(TypeAnnotation))
   Record(RecordDefinition)
+  GenericRecord(GenericName, RecordDefinition)
 }
 
 pub type RecordDefinition {

--- a/src/glelm.gleam
+++ b/src/glelm.gleam
@@ -17,10 +17,11 @@ pub type RuntimeError(ctx) {
 pub fn run() {
   let elm_src =
     "
-type FooBar a
-    = Bar (Result String a)
-    | Baz (Int, Int)
-    | Qux { str: String, int: a }
+type Foo a
+     = Foo { field1: (Bar a, Int) }
+     | Bar { field1: Maybe a,
+             field2: Either a String }
+     | Baz (Foo ())
 "
   io.print(elm_src)
   io.println("")
@@ -68,76 +69,3 @@ pub fn main() {
     _ -> debug.log("Unknown error")
   }
 }
-// fn print_glance_output() {
-//   let gleam =
-//     "
-// pub type Foo(a) {
-//   Foo(field: String, bar: a)
-//   Baz(String)
-// }
-// "
-//   use ast <- result.try(glance.module(gleam))
-//   io.debug(ast)
-//   let source = glance_printer.print(ast)
-//   io.print(source)
-//   Ok(Nil)
-// }
-// fn calculator() {
-//   use ast <- result.try(
-//     lexer.new()
-//     |> lexer.run("1 * 2 + 3")
-//     |> result.map(nibble.run(_, expression())),
-//   )
-//   Ok(ast)
-// }
-
-// type Expression {
-//   Addition(Expression, Expression)
-//   Multiplication(Expression, Expression)
-//   Number(Float)
-// }
-
-// fn term() {
-//   nibble.one_of([number(), sum()])
-// }
-
-// fn sum() {
-//   use lhs <- nibble.do(expression())
-//   use _ <- nibble.do(nibble.token(lexer.Plus))
-//   use rhs <- nibble.do(expression())
-//   nibble.succeed(Addition(lhs, rhs))
-// }
-
-// fn number() {
-//   nibble.take_map("Expected float or int literal", fn(tok) {
-//     case tok {
-//       lexer.FloatLiteral(f) -> Some(Number(f))
-//       lexer.IntLiteral(i) -> Some(Number(int.to_float(i)))
-//       _ -> None
-//     }
-//   })
-// }
-
-// fn expression() {
-//   nibble.one_of([sub_expression(), number()])
-// }
-
-// fn sub_expression() {
-//   use num <- nibble.do(number())
-//   use expr <- nibble.do({
-//     use op <- nibble.take_map("Expected operator")
-//     case op {
-//       lexer.Plus -> Some(Addition)
-//       lexer.Multiply -> Some(Multiplication)
-//       _ -> None
-//     }
-//   })
-//   use rhs <- nibble.do(expression())
-//   nibble.succeed(expr(num, rhs))
-// }
-
-// pub fn main() {
-//   use ast <- result.try(calculator())
-//   io.debug(ast)
-//   Ok("")
-// }

--- a/src/transpile.gleam
+++ b/src/transpile.gleam
@@ -57,7 +57,13 @@ pub fn custom_type(
 fn variant(constructor: elm.ValueConstructor) -> glance.Variant {
   let elm.ValueConstructor(elm.TypeName(name), arguments) = constructor
   case arguments {
-    [elm.Record(elm.RecordDefinition(fields))] -> record(name, fields)
+    // Currently, generic records are represented as regular
+    // records in Gleam.
+    // TODO: Emit a warning.
+    [elm.Record(def)] | [elm.GenericRecord(_, def)] -> {
+      let elm.RecordDefinition(fields) = def
+      record(name, fields)
+    }
     _ ->
       glance.Variant(
         name,
@@ -95,7 +101,7 @@ fn type_annotation(ann: elm.TypeAnnotation) -> glance.Type {
         None,
         annotations |> list.map(type_annotation),
       )
-    elm.Record(_record_definition) ->
+    elm.Record(_) | elm.GenericRecord(_, _) ->
       panic as "Multiple record type annotations are not supported"
   }
 }

--- a/test/transpile/type_annotation_record.elm.input
+++ b/test/transpile/type_annotation_record.elm.input
@@ -2,3 +2,4 @@ type Foo a
   = Bar { field1: String,
           field2: (Int, String),
           field3: Maybe a }
+  | Baz { a | field4 : Float }

--- a/test/transpile/type_annotation_record.gleam.expected
+++ b/test/transpile/type_annotation_record.gleam.expected
@@ -1,3 +1,4 @@
 pub type Foo(a) {
   Bar(field1: String, field2: #(Int, String), field3: Maybe(a))
+  Baz(field4: Float)
 }

--- a/tools/elm-syntax/src/Main.elm
+++ b/tools/elm-syntax/src/Main.elm
@@ -1,6 +1,7 @@
 module Main exposing (..)
 
 import Browser
+import Debug
 import Elm.Interface exposing (Exposed(..))
 import Elm.Parser
 import Elm.Syntax.File as File
@@ -122,12 +123,5 @@ view { src } =
 
 main : Program () Model Msg
 main =
-    Browser.sandbox { init = init, update = update, view = view }
-
-
-type Foo a
-    = Bar Maybe a
-
-
-a =
-    Bar "a" 1
+    Browser.sandbox
+        { init = init, update = update, view = view }


### PR DESCRIPTION
This adds parsing of generic records without any special handling.
Generic records are mapped to simple Gleam records.

For example:

```elm
type A = A { a | foo : Int }
```

gets translated to:

```gleam
type A {
  A(foo: Int)
}
```

<!-- ps-id: 2f385339-c4f8-4fe9-b589-23ba898d1d6f -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bilus/glelm/7)
<!-- Reviewable:end -->
