### PR TITLE
Handle comments.

### DIFF
--- a/src/glelm.gleam
+++ b/src/glelm.gleam
@@ -16,20 +16,12 @@ pub type RuntimeError(ctx) {
 
 pub fn run() -> Result(String, RuntimeError(a)) {
   let elm_src =
-    "module Foo
+    "module Comments
 
-type RelativePosition
-    = OnRight
-    | OnLeft
-    | Above
-    | Below
-    | InFront
-
-
-type Layout
-    = GridElement
-    | Row
-    | Column
+-- Comment
+type A {-Foo--}= {-
+  Comment
+-} A Int--Comment
 "
   io.println(elm_src)
   use elm_ast <- result.try(

--- a/test/transpile/comments.elm.input
+++ b/test/transpile/comments.elm.input
@@ -1,0 +1,6 @@
+module Comments
+
+-- Comment 1
+-- Comment 2
+type {-- Comment 3 --} A {- Multiline
+comment -}= {--} A -- Comment 4

--- a/test/transpile/comments.gleam.expected
+++ b/test/transpile/comments.gleam.expected
@@ -1,0 +1,3 @@
+pub type A {
+  A()
+}

--- a/tools/elm-syntax/src/Main.elm
+++ b/tools/elm-syntax/src/Main.elm
@@ -125,20 +125,3 @@ main : Program () Model Msg
 main =
     Browser.sandbox
         { init = init, update = update, view = view }
-
-
-type A
-    = A (Maybe { a : Int })
-
-
-foo : { a : Int } -> ()
-foo x =
-    ()
-
-
-bar =
-    let
-        a =
-            A (Just { a = 10 })
-    in
-    foo a


### PR DESCRIPTION
This strips multi- and single-line comments. It uses a Matcher to parse
them into tokens so when I get to the point where I want to generate doc
strings in Gleam, I can use the tokens to do that.

<!-- ps-id: ec0e8548-0216-423f-ad07-287ca6765ac9 -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bilus/glelm/10)
<!-- Reviewable:end -->
