### PR TITLE
Type aliases.

### DIFF
--- a/src/glelm.gleam
+++ b/src/glelm.gleam
@@ -41,12 +41,6 @@ pub fn run() -> Result(String, RuntimeError(a)) {
   let gleam_src = transpile.print(gleam_ast)
   debug.log("*** GLEAM SRC")
   io.print(gleam_src)
-  use gleam_ast2 <- result.try(
-    glance.module(gleam_src) |> result.map_error(GlanceError),
-  )
-  debug.log("*** GLEAM AST 2")
-  debug.log(gleam_ast2)
-
   Ok(gleam_src)
 }
 

--- a/src/glelm/elm/ast.gleam
+++ b/src/glelm/elm/ast.gleam
@@ -4,6 +4,7 @@ pub type Module {
 
 pub type Declaration {
   CustomTypeDeclaration(Type)
+  AliasDeclaration(TypeAlias)
 }
 
 pub type TypeName {
@@ -23,6 +24,21 @@ pub type Type {
 
 pub type ValueConstructor {
   ValueConstructor(name: TypeName, arguments: List(TypeAnnotation))
+}
+
+/// Type alias that defines the syntax for an alias for a type.
+///
+/// Example:
+///    type alias Person =
+///        { name : String
+///          , age : Int
+///        }
+pub type TypeAlias {
+  TypeAlias(
+    name: TypeName,
+    generics: List(GenericName),
+    type_annotation: TypeAnnotation,
+  )
 }
 
 /// Custom type for different type annotations.

--- a/src/glelm/elm/lexer.gleam
+++ b/src/glelm/elm/lexer.gleam
@@ -33,7 +33,7 @@ pub type Token {
   //-----------------------------------
   // Composite keywords
   //-----------------------------------
-  TypeAliasKeyword
+  AliasKeyword
   PortModuleKeyword
   ModuleKeyword
 
@@ -139,7 +139,7 @@ pub fn new() -> Lexer {
       lexer.keyword("where", "\\s+", WhereKeyword),
       lexer.keyword("do", "\\s+", DoKeyword),
       // Composite keywords
-      lexer.keyword("type alias", "\\s+", TypeAliasKeyword),
+      lexer.keyword("alias", "\\s+", AliasKeyword),
       lexer.keyword("port module", "\\s+", PortModuleKeyword),
       lexer.keyword("module", "\\s+", ModuleKeyword),
       // Basic keywords

--- a/src/glelm/transpile.gleam
+++ b/src/glelm/transpile.gleam
@@ -2,12 +2,13 @@ import eval.{type Eval}
 import glance
 import glance_printer
 import gleam/list
-import gleam/option.{None}
+import gleam/option.{None, Some}
+import gleam/pair
 import glelm/elm/ast as elm
 import glelm/transpile/context.{type Context}
 
 pub type Error {
-  Error(glance.Error)
+  TranspileError(glance.Error)
 }
 
 pub type Transpiler(a) =
@@ -19,16 +20,17 @@ pub fn initial_ctx() -> Context {
 
 pub fn module(elm_ast: elm.Module) -> Transpiler(glance.Module) {
   use _ <- eval.try(elm_ast.exposing |> context.handle_exposing)
-  use custom_types <- eval.try(
-    elm_ast.declarations
-    |> list.map(fn(decl) {
-      let elm.CustomTypeDeclaration(custom_type) = decl
-      custom_type
-    })
-    |> list.map(fn(type_) { custom_type(type_) })
-    |> eval.all(),
+  use #(custom_types, type_aliases) <- eval.try(
+    declarations(elm_ast.declarations)
+    |> eval.map(partition_declarations),
   )
-  glance.Module([], custom_types, [], [], [])
+  glance.Module(
+    imports: [],
+    custom_types:,
+    type_aliases:,
+    constants: [],
+    functions: [],
+  )
   |> eval.return
 }
 
@@ -39,13 +41,107 @@ pub fn run(t: Transpiler(a), s: Context) -> Result(a, Error) {
 pub fn print(module: glance.Module) -> String {
   // It seems to reverse the order when outputting Gleam source code.
   let module =
-    glance.Module(..module, custom_types: module.custom_types |> list.reverse)
+    glance.Module(
+      ..module,
+      custom_types: module.custom_types |> list.reverse,
+      type_aliases: module.type_aliases |> list.reverse,
+    )
   glance_printer.print(module)
 }
 
-pub fn custom_type(
-  type_: elm.Type,
-) -> Transpiler(glance.Definition(glance.CustomType)) {
+// Used internally to facilitate generation of glance declarations.
+type Decl {
+  CustomType(glance.Definition(glance.CustomType))
+  TypeAlias(glance.Definition(glance.TypeAlias))
+}
+
+fn declarations(declarations: List(elm.Declaration)) -> Transpiler(List(Decl)) {
+  declarations
+  |> list.map(fn(decl) {
+    case decl {
+      elm.CustomTypeDeclaration(type_) -> custom_type(type_)
+
+      elm.AliasDeclaration(alias) -> type_alias(alias)
+    }
+  })
+  |> eval.all
+}
+
+// Glance puts aliases before custom types in the generated output and uses
+// separate Definition type for each, unlike Elm AST which preserves their
+// original relative positions in the source.
+fn partition_declarations(
+  declarations: List(Decl),
+) -> #(
+  List(glance.Definition(glance.CustomType)),
+  List(glance.Definition(glance.TypeAlias)),
+) {
+  declarations
+  |> list.map(fn(decl) {
+    case decl {
+      CustomType(def) -> #(Some(def), None)
+      TypeAlias(def) -> #(None, Some(def))
+    }
+  })
+  |> list.unzip
+  |> pair.map_first(option.values)
+  |> pair.map_second(option.values)
+}
+
+fn type_alias(alias: elm.TypeAlias) -> Transpiler(Decl) {
+  use _ <- eval.try(context.handle_type_alias(alias))
+  let elm.TypeAlias(elm.TypeName(name), generics, ann) = alias
+
+  use context.Visibility(is_public:, is_opaque: _) <- eval.try(
+    context.visibility(name),
+  )
+  case ann {
+    elm.GenericType(_) | elm.Unit | elm.Tupled(_) | elm.Typed(_, _) ->
+      type_alias_for_aliasable_type(name, is_public, generics, ann)
+      |> eval.map(TypeAlias)
+    elm.Record(_) | elm.GenericRecord(_, _) | elm.FunctionType(_, _) -> {
+      let constructors = [elm.ValueConstructor(alias.name, [ann])]
+      type_alias_fallback(name, is_public, is_public, generics, constructors)
+      |> eval.map(CustomType)
+    }
+  }
+}
+
+fn type_alias_for_aliasable_type(
+  name: String,
+  is_public: Bool,
+  generics: List(String),
+  ann: elm.TypeAnnotation,
+) -> Transpiler(glance.Definition(glance.TypeAlias)) {
+  glance.Definition(
+    [],
+    glance.TypeAlias(name, publicity(is_public), generics, type_annotation(ann)),
+  )
+  |> eval.return
+}
+
+fn type_alias_fallback(
+  name: String,
+  is_public: Bool,
+  is_opaque: Bool,
+  generics: List(elm.GenericName),
+  constructors: List(elm.ValueConstructor),
+) {
+  glance.Definition(
+    [],
+    glance.CustomType(
+      name,
+      publicity(is_public),
+      is_opaque,
+      generics,
+      constructors
+        |> list.map(variant),
+    ),
+  )
+  |> eval.return
+}
+
+fn custom_type(type_: elm.Type) -> Transpiler(Decl) {
   use _ <- eval.try(context.handle_custom_type(type_))
 
   let elm.Type(elm.TypeName(name), generics, constructors) = type_
@@ -57,10 +153,7 @@ pub fn custom_type(
     [],
     glance.CustomType(
       name,
-      case is_public {
-        True -> glance.Public
-        False -> glance.Private
-      },
+      publicity(is_public),
       is_opaque,
       generics,
       constructors
@@ -68,6 +161,14 @@ pub fn custom_type(
     ),
   )
   |> eval.return
+  |> eval.map(CustomType)
+}
+
+fn publicity(is_public: Bool) -> glance.Publicity {
+  case is_public {
+    True -> glance.Public
+    False -> glance.Private
+  }
 }
 
 fn variant(constructor: elm.ValueConstructor) -> glance.Variant {

--- a/src/glelm/transpile/context.gleam
+++ b/src/glelm/transpile/context.gleam
@@ -50,9 +50,21 @@ fn expose_to_export(expose: elm.TopLevelExpose) -> #(String, Export) {
   }
 }
 
+// TODO: Merge handle_custom_type and handle_type_alias
 pub fn handle_custom_type(type_: elm.Type) -> Eval(Nil, e, Context) {
   use ctx: Context <- context.update()
   let elm.TypeName(name) = type_.name
+  let exposing = case ctx.exposing {
+    AllPublic(exposing) ->
+      AllPublic(exposing |> dict.insert(name, TypeOrAliasExport(False)))
+    other -> other
+  }
+  Context(exposing: exposing)
+}
+
+pub fn handle_type_alias(alias: elm.TypeAlias) -> Eval(Nil, e, Context) {
+  use ctx: Context <- context.update()
+  let elm.TypeName(name) = alias.name
   let exposing = case ctx.exposing {
     AllPublic(exposing) ->
       AllPublic(exposing |> dict.insert(name, TypeOrAliasExport(False)))

--- a/test/transpile/function_type_annotation.elm.input
+++ b/test/transpile/function_type_annotation.elm.input
@@ -1,3 +1,6 @@
 module FunctionTypeAnnotation
 
 type Fun a = Fun ((Maybe a) -> Int -> Int -> (Maybe a))
+
+-- type State state value =
+--     State (state -> ( value, state ))

--- a/test/transpile/type_alias.elm.input
+++ b/test/transpile/type_alias.elm.input
@@ -1,0 +1,14 @@
+module TypeAlias exposing (Foo)
+
+type alias Foo = Maybe Int
+
+type alias Option a = Maybe a
+
+type alias Pair a b = (a, b)
+
+type alias Unit = ()
+
+type alias State state value =
+      state -> ( value, state )
+
+type alias Bar a = { baz: Maybe a, qux: a }

--- a/test/transpile/type_alias.gleam.expected
+++ b/test/transpile/type_alias.gleam.expected
@@ -1,0 +1,19 @@
+type State(state, value) {
+  State(fn(state) -> #(value, state))
+}
+
+type Bar(a) {
+  Bar(baz: Maybe(a), qux: a)
+}
+
+pub type Foo =
+  Maybe(Int)
+
+type Option(a) =
+  Maybe(a)
+
+type Pair(a, b) =
+  #(a, b)
+
+type Unit =
+  Nil


### PR DESCRIPTION
This adds support for type aliases. Elm type aliases to existing types,
including generics, as well as aliases to tuples and units are generated
as Gleam aliases, while aliases to records and functions are defined as
types, because that's the only way they can be expressed in Gleam I'm
aware of.

<!-- ps-id: 542aaa75-a890-4547-be7a-187465c6e184 -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bilus/glelm/14)
<!-- Reviewable:end -->
